### PR TITLE
Get info gempa refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .env
 yarn-error.log
 config.js
+*.temp.txt

--- a/actions/getGempa.js
+++ b/actions/getGempa.js
@@ -69,6 +69,8 @@ const getData = async() => {
 
           if (currentData !== resultString) {
             currentData = resultString;
+            limitter = {};
+            blockedUser = {};
             bot.telegram.sendMessage(config.chatId, buildResponse(), {
               parse_mode: 'Markdown'
             });

--- a/actions/getGempa.js
+++ b/actions/getGempa.js
@@ -1,7 +1,58 @@
+require('format-unicorn');
+const R = require('ramda');
+const config = require('../config');
+const bot = require('../bot');
+const fs = require('fs');
+const path = require('path');
 const request = require('request');
 const parseString = require('xml2js').parseString;
+const jadwalin = require('jadwalin');
 
-const getGempa = async(context) => {
+const PATH = path.resolve(__dirname, 'gempa.temp.txt');
+let limitter = {};
+let blockedUser = {};
+let currentData = '{"data": {}}';
+
+const template = `
+*Tanggal : * {tanggal}
+*Jam : * {jam}
+*Lintang : * {lintang}
+*Bujur : * {bujur}
+*Magnitude : * {magnitude}
+*Kedalaman : * {kedalaman}
+*Potensi : * {potensi}
+*Lokasi : * {lokasi}
+`;
+
+// persist data into file on exit
+process.on('SIGINT', function() {
+  fs.writeFile(PATH, currentData, function(err) {
+    console.log(err); // eslint-disable-line
+    process.exit();
+  });
+});
+
+// restore data from persistent
+fs.readFile(PATH, 'utf8', function(err, data) {
+  currentData = data;
+});
+
+
+const buildResponse = () => {
+  const parsedCurrentData = JSON.parse(currentData);
+  return template.formatUnicorn({
+    tanggal: R.pathOr('Tidak diketahui', ['Tanggal', '0'], parsedCurrentData),
+    jam: R.pathOr('Tidak diketahui', ['Jam', '0'], parsedCurrentData),
+    lintang: R.pathOr('Tidak diketahui', ['Lintang', '0'], parsedCurrentData),
+    bujur: R.pathOr('Tidak diketahui', ['Bujur', '0'], parsedCurrentData),
+    magnitude: R.pathOr('Tidak diketahui', ['Magnitude', '0'], parsedCurrentData),
+    kedalaman: R.pathOr('Tidak diketahui', ['Kedalaman', '0'], parsedCurrentData),
+    potensi: R.pathOr('Tidak diketahui', ['Potensi', '0'], parsedCurrentData),
+    lokasi: R.pathOr('Tidak diketahui', ['Wilayah1', '0'], parsedCurrentData)
+  });
+};
+
+const getData = async() => {
   const options = {
     url: 'http://data.bmkg.go.id/autogempa.xml',
     headers: {
@@ -12,31 +63,46 @@ const getGempa = async(context) => {
   request(options, function (error, response, body) {
     if (!error && response.statusCode === 200) {
       try {
-        let data= '';
-        var data_; 
-        parseString(body, 
-          function (err, result) {				
-            data_=result.Infogempa.gempa[0];		
+        parseString(body, (err, res) => {
+          const result = res.Infogempa.gempa[0];
+          const resultString = JSON.stringify(result);
+
+          if (currentData !== resultString) {
+            currentData = resultString;
+            bot.telegram.sendMessage(config.chatId, buildResponse(), {
+              parse_mode: 'Markdown'
+            });
           }
-        );
-        data = `
-*Tanggal : * ${data_.Tanggal[0]}
-*Jam : * ${data_.Jam[0]}
-*Lintang : * ${data_.Lintang[0]}
-*Bujur : * ${data_.Bujur[0]}
-*Magnitude : * ${data_.Magnitude[0]}
-*Kedalaman : * ${data_.Kedalaman[0]}
-*Potensi : * ${data_.Potensi[0]}
-*Lokasi : * ${data_.Wilayah1[0]}
-          `;
-        context.replyWithMarkdown(data);
+        });
       } catch (err) {
-        context.reply('Maaf terjadi gangguan');
+        console.log(err) // eslint-disable-line
       }
     } else {
-      context.reply('Jaringan bermasalah');
+      // should logged into real logger in the future
+      console.log('error'); // eslint-disable-line
     }
   });
+};
+
+const scheduler1 = new jadwalin(getData);
+const limitResetter = new jadwalin(() => {
+  limitter = {};
+  blockedUser = {};
+});
+limitResetter.setiapJam('1:10');
+scheduler1.setiap(1000 * 60);
+getData();
+
+const getGempa = async(context) => {
+  const username = context.update.message.from.username;
+  if (limitter[username]) {
+    if (!blockedUser[username]) {
+      context.reply('jangan nanya mulu kak, kan tadi udah! datanya tetep sama kok, nanti kalo ada info gempa baru, aku kabarin deh!');
+    }
+  } else {
+    limitter[username] = true;
+    context.replyWithMarkdown(buildResponse());
+  }
 };
 
 module.exports = getGempa;

--- a/bot.js
+++ b/bot.js
@@ -1,0 +1,3 @@
+const Telegraf = require('telegraf');
+const config = require('./config');
+module.exports = new Telegraf(config.botToken, {username: 'mbak_hayati_bot'});

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
-const Telegraf = require('telegraf');
 const routes = require('./routes');
-const config = require('./config');
-const bot = new Telegraf(config.botToken, {username: 'mbak_hayati_bot'});
+const bot = require('./bot');
 
 const misuhLimit = {};
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.2",
     "dotenv": "^5.0.0",
+    "format-unicorn": "^1.1.1",
     "google-translate-api": "vitalets/google-translate-api",
     "idx": "^2.5.2",
     "jadwalin": "0.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,6 +472,11 @@ form-data@~2.3.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+format-unicorn@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/format-unicorn/-/format-unicorn-1.1.1.tgz#533423f9c6bdb261bf508fff54f2d7a9b27a2251"
+  integrity sha1-UzQj+ca9smG/UI//VPLXqbJ6IlE=
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"


### PR DESCRIPTION
## Summary
Pada Pull Request ini saya membuat perubahan terhadap mekanisme command `/gempa`. Jika sebelumnya setiap kita memberikan perintah `/gempa` kepada hayati, hayati selalu menjawab dengan jawaban yang sama karena memang saat itu tidak ada perubahan data gempa dari bmkg

Hal ini menyebabkan abusing terhadap command `/gempa`

<img width="458" alt="screen shot 2018-12-11 at 21 43 29" src="https://user-images.githubusercontent.com/10051243/49807930-dd4fa300-fd8d-11e8-911b-3f056d473351.png">

maka dari itu pada PR ini saya mengenalkan mekanisme limitter dan blocker, yang artinya user tidak lagi bisa menanyakan info gempa berulang2 karena ada mekanisme limit yaitu user hanya boleh menanyakan info gempa, sekali dalam sehari. jika user menanyakan dua kali maka hayati akan menjawab `jangan nanya mulu kak, kan tadi udah! datanya tetep sama kok, nanti kalo ada info gempa baru, aku kabarin deh!` dan jika user memaksa nanya 3 kali, hayati tidak akan menjawab sampai hari berikutnya / ketika data gempa telah berubah.

### Notification

pada PR ini saya juga menambahkan fitur notif, setiap 1 menit sekali hayati akan melakukan request data gempa kepada api bmkg dan akan membandingkan dengan data sebelumnya, jika terdapat perbedaan, hayati akan memberikan info gempa tanpa kita tanya.

### Persistent Data

Saya juga menambahkan logic untuk menyimpan data gempa menjadi sebuah file txt, hal ini ditujukan untuk membackup state data gempa jika aplikasi exit/restart. mekanisme ini juga disebut dengan `gracefully shutdown`